### PR TITLE
Detect operating system before invoking CMD

### DIFF
--- a/src/foxsylv/bwa/BWAConsoleUI.java
+++ b/src/foxsylv/bwa/BWAConsoleUI.java
@@ -7,23 +7,23 @@ import java.io.IOException;
 /**
  * An implementation of the Bookworm Magic Pen commands
  * using only the Windows console
- * 
+ *
  * @author FoxSylv
  */
 public class BWAConsoleUI {
 	public static void main(String[] args) throws IOException {
-		if (args.length == 0) {
+		if (System.getProperty("os.name").toLowerCase().contains("win") && args.length == 0) {
 			Runtime.getRuntime().exec(new String[]{"cmd","/c","start","cmd","/k","java -jar \"Offline_Pen.jar\" Thanks for playing!"});
 		}
 		Scanner scanner = new Scanner(System.in);
-		
+
 		System.out.println("Welcome to FoxSylv's offline Magic Pen trainer! ^w^");
 		System.out.println("Type \"help\" for a list of commands if you're confused at any point!\n");
-		
+
 		while (true) {
 			String rawInput = scanner.nextLine();
 			String[] keywords = rawInput.split(" ");
-			
+
 			System.out.println();
 			String result = BWACommandHandler.callCommand(keywords[0], Arrays.copyOfRange(keywords, 1, keywords.length));
 			System.out.println(result);


### PR DESCRIPTION
Uses `System.getProperty("os.name").toLowerCase().contains("win")` to determine if the program is running on a Windows computer and conditionally invoke the command prompt.

Closes #4.